### PR TITLE
GRIN-257: Add healthchecks for php container

### DIFF
--- a/api/Chart.yaml
+++ b/api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: API Chart based on nginx and php-fpm
 name: api
-version: 5.1.0
-appVersion: 5.1.0
+version: 5.1.1
+appVersion: 5.1.1
 home: https://www.thecolvinco.com
 icon: view-source:https://www.thecolvinco.com/favicon-192.png
 sources:

--- a/api/templates/deployment.yaml
+++ b/api/templates/deployment.yaml
@@ -48,6 +48,18 @@ spec:
         - name: php
           image: "{{ .Values.php.image.repository }}:{{ .Values.php.image.tag }}"
           imagePullPolicy: {{ .Values.php.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command:
+              - ls
+              - /srv/socket/fpm.sock
+            initialDelaySeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - ls
+              - /srv/socket/fpm.sock
+            initialDelaySeconds: 5
           envFrom:
 {{- if .Values.php.envFrom }}
 {{ toYaml .Values.php.envFrom | indent 12 }}
@@ -72,6 +84,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
+      terminationGracePeriodSeconds: 60
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
To prevent random errors in deploys due to the delay in starting the php container.